### PR TITLE
Fix virtualenv_rootpath and Makefile

### DIFF
--- a/{{cookiecutter.directory_name}}/.vscode/settings.json
+++ b/{{cookiecutter.directory_name}}/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-    "python.pythonPath": "{{ virtualenv_rootpath }}/{{ cookiecutter.project_slug }}/bin/python",
+    "python.pythonPath": "{{ cookiecutter.virtualenv_rootpath }}/{{ cookiecutter.project_slug }}/bin/python",
     "python.formatting.provider": "black",
     "python.formatting.blackArgs": [
         "--line-length=100"
     ],
-    "python.venvPath": "{{ virtualenv_rootpath }}/{{ cookiecutter.project_slug }}"
+    "python.venvPath": "{{ cookiecutter.virtualenv_rootpath }}/{{ cookiecutter.project_slug }}"
 }

--- a/{{cookiecutter.directory_name}}/Makefile
+++ b/{{cookiecutter.directory_name}}/Makefile
@@ -28,4 +28,4 @@ clean_queue:
 	docker-compose start celery celery_beat
 
 autopep8:
-    find . -name "*py" | xargs autopep8 --in-place --aggressive --aggressive --max-line-length 100
+	find . -name "*py" | xargs autopep8 --in-place --aggressive --aggressive --max-line-length 100


### PR DESCRIPTION
Faltava um cookiecutter na variável virtualenv_rootpath e a ação autopep8 do Makefile estava definida com espaços no lugar do tab