### PR TITLE
Fix postgres docker volume

### DIFF
--- a/{{cookiecutter.directory_name}}/docker-compose-dev.yml
+++ b/{{cookiecutter.directory_name}}/docker-compose-dev.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:9.6.0
     restart: always
     volumes:
-      - ../pgdata:/var/lib/postgresql/data
+      - {{ cookiecutter.project_slug }}_pgdata:/var/lib/postgresql/data
     environment:
       - LC_ALL=C.UTF-8
       - POSTGRES_PASSWORD={{ cookiecutter.project_slug }}
@@ -17,4 +17,7 @@ services:
     image: redis
     ports:
       - 6379:6379
+
+volumes:
+  {{ cookiecutter.project_slug }}_pgdata:
   

--- a/{{cookiecutter.directory_name}}/docker-compose.yml
+++ b/{{cookiecutter.directory_name}}/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:9.6.0
     restart: always
     volumes:
-      - ../pgdata:/var/lib/postgresql/data
+      - {{ cookiecutter.project_slug }}_pgdata:/var/lib/postgresql/data
     environment:
       - LC_ALL=C.UTF-8
       - POSTGRES_PASSWORD={{ cookiecutter.project_slug }}
@@ -75,3 +75,6 @@ services:
       - app
     depends_on:
       - app
+
+volumes:
+  {{ cookiecutter.project_slug }}_pgdata:


### PR DESCRIPTION
Somente alterei o do postgres, os demais antes utilizavam um diretório dentro do projeto então não senti necessidade de transformar em volumes.

A solução foi criar um volume docker para o pgdata, antes o diretório era fora do projeto, o que causava erros com docker-compose sendo necessário corrigir manualmente.